### PR TITLE
Fix 'failed loading templates'

### DIFF
--- a/initServer.sqf
+++ b/initServer.sqf
@@ -1,3 +1,3 @@
-call compile preprocessFileLineNumbers "westNatoVanilla.sqf";
-call compile preprocessFileLineNumbers "independentAafVanilla.sqf";
-call compile preprocessFileLineNumbers "eastCsatVanilla.sqf";
+call compile preprocessFileLineNumbers "resources\templates\westNatoVanilla.sqf";
+call compile preprocessFileLineNumbers "resources\templates\independentAafVanilla.sqf";
+call compile preprocessFileLineNumbers "resources\templates\eastCsatVanilla.sqf";


### PR DESCRIPTION
Fix 'failed loading templates' by adding correct path to 'preprocessFileLineNumbers' of the templates in initServer.sqf.